### PR TITLE
chore: add the namespace to the tp command and update the MOUNT_VOLUME_LOCAL

### DIFF
--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -26,7 +26,7 @@ set_os_arch() {
     case $uname in
         "Darwin")
             OS="darwin"
-            MOUNT_VOLUME_LOCAL=~/Library/Application\ Support
+            MOUNT_VOLUME_LOCAL=~/Library/Application Support
             ;;
         "Linux")
             OS="linux"
@@ -111,7 +111,7 @@ connect_local_dev_env_to_remote() {
     export KUBECONFIG=./emojivoto_k8s_context.yaml
     echo 'Connecting local dev env to remote K8s cluster'
     telepresence login --apikey=$AMBASSADOR_API_KEY
-    telepresence intercept web-app-57bc7c4959 --service web-app --port 8083:80 --ingress-port 80 --ingress-host ambassador.ambassador --ingress-l5 ambassador.ambassador
+    telepresence intercept web-app-57bc7c4959 -n emojivoto --service web-app --port 8083:80 --ingress-port 80 --ingress-host ambassador.ambassador --ingress-l5 ambassador.ambassador
     telOut=$?
     if [ $telOut != 0 ]; then
         exit $telOut


### PR DESCRIPTION
### What?

- Add the namespace to the telepresence command
- Update the MOUNT_VOLUME_LOCAL for mac

### Why?

- The telepresence command was not able to find the service to intercept and the solution was to specify in the tp command or set the default namespace to emojivoto in the kube config, we decided to go for the first option.
- The old value was causing errors when try to run the docker command